### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,9 @@ class ItemsController < ApplicationController
   #ログイン状態によって表示するページを切り替えるコードでログインしていなければ、ログイン画面に遷移さる。
   before_action :authenticate_user!, only: [:new, :create, :edit]
   #ログインしていて、出品したユーザーとログインユーザーが違かったら編集ページに行けないように制限している
-  before_action :move_to_index, only: :edit
+  before_action :move_to_index, only: [:edit, :update]
+  #各アクションで使用しているコードを１つにまとめる
+  before_action :set_item, only: [:show, :edit, :update]
 
   # トップページを表示
   def index
@@ -27,17 +29,17 @@ class ItemsController < ApplicationController
 
   # 商品詳細ページを表示
   def show
-    @item = Item.find(params[:id])
+    #before_actionで呼び出している
   end
 
   #編集ページを表示
   def edit
-    @item = Item.find(params[:id])
+    #before_actionで呼び出している
   end
 
   #出品情報が更新されたら、保存される
   def update
-    @item = Item.find(params[:id])
+    #before_actionで呼び出している
       if @item.update(item_params)
         redirect_to root_path
       else
@@ -60,4 +62,9 @@ private
     unless current_user.id == @item.user_id
       redirect_to action: :index
     end
+  end
+
+  #before_actionで同じコードをまとめた
+  def set_item
+    @item = Item.find(params[:id])
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
-  # ログインしていないユーザーは、ログイン画面に遷移する
-  before_action :authenticate_user!, only: [:new, :create]
+  #ログイン状態によって表示するページを切り替えるコードでログインしていなければ、ログイン画面に遷移さる。
+  before_action :authenticate_user!, only: [:new, :create, :edit]
+  #ログインしていて、出品したユーザーとログインユーザーが違かったら編集ページに行けないように制限している
+  before_action :move_to_index, only: :edit
 
   # トップページを表示
   def index
@@ -46,7 +48,16 @@ end
 
 private
 
-def item_params
-  params.require(:item).permit(:product, :product_description, :category_id, :status_id, :ship_base_id, :prefecture_id,
-                               :ship_date_id, :price, :image).merge(user_id: current_user.id)
-end
+  #imteモデルの情報から所得する制限をかけた
+  def item_params
+    params.require(:item).permit(:product, :product_description, :category_id, :status_id, :ship_base_id, :prefecture_id,
+                                :ship_date_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  #編集ページにアクセスする際、投稿したユーザー出ないとアクセスでいないように条件分岐している
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless current_user.id == @item.user_id
+      redirect_to action: :index
+    end
+  end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,12 +31,17 @@ end
 
 #編集ページを表示
 def edit
-  
+  @item = Item.find(params[:id])
 end
 
 #出品情報が更新されたら、保存される
 def update
-  
+  @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit             
+    end
 end
 
 private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,21 +27,21 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
-end
 
-#編集ページを表示
-def edit
-  @item = Item.find(params[:id])
-end
+  #編集ページを表示
+  def edit
+    @item = Item.find(params[:id])
+  end
 
-#出品情報が更新されたら、保存される
-def update
-  @item = Item.find(params[:id])
-    if @item.update(item_params)
-      redirect_to root_path
-    else
-      render :edit             
-    end
+  #出品情報が更新されたら、保存される
+  def update
+    @item = Item.find(params[:id])
+      if @item.update(item_params)
+        redirect_to root_path
+      else
+        render :edit             
+      end
+  end
 end
 
 private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,6 +29,16 @@ class ItemsController < ApplicationController
   end
 end
 
+#編集ページを表示
+def edit
+  
+end
+
+#出品情報が更新されたら、保存される
+def update
+  
+end
+
 private
 
 def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
   #ログイン状態によって表示するページを切り替えるコードでログインしていなければ、ログイン画面に遷移さる。
   before_action :authenticate_user!, only: [:new, :create, :edit]
-  #ログインしていて、出品したユーザーとログインユーザーが違かったら編集ページに行けないように制限している
-  before_action :move_to_index, only: [:edit, :update]
   #各アクションで使用しているコードを１つにまとめる
   before_action :set_item, only: [:show, :edit, :update]
+  #ログインしていて、出品したユーザーとログインユーザーが違かったら編集ページに行けないように制限している
+  before_action :move_to_index, only: [:edit, :update]
 
   # トップページを表示
   def index
@@ -56,15 +56,14 @@ private
                                 :ship_date_id, :price, :image).merge(user_id: current_user.id)
   end
 
-  #編集ページにアクセスする際、投稿したユーザー出ないとアクセスでいないように条件分岐している
-  def move_to_index
-    @item = Item.find(params[:id])
-    unless current_user.id == @item.user_id
-      redirect_to action: :index
-    end
-  end
-
   #before_actionで同じコードをまとめた
   def set_item
     @item = Item.find(params[:id])
+  end
+  
+  #編集ページにアクセスする際、投稿したユーザー出ないとアクセスでいないように条件分岐している
+  def move_to_index
+    unless current_user.id == @item.user_id
+      redirect_to action: :index
+    end
   end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,9 +9,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# 保存に失敗したらエラーが表示されるように部分テンプレートを呼び出している %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :product_description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:ship_base_id, ShipBase.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:ship_date_id, ShipDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
     <%# /ログイン状態かつ出品者かどうかの条件いよって表示するボタンを決めている %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   #トップページを表示させるコード
   root to: 'items#index'
   #商品出品機能に必要なアクション
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
what
・商品情報の編集機能を実装した

why
・後から情報を変更したい時が出てくると思うので、変更できるようにした

以下、添付動画
1,ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/aeaad08018b9f9878e783362a55d28c8

2,正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/72ae50d92f58da7afdc003b95f43ed82

3,入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/774bcf4084f71e01aecc6123bd5d7613

4,何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/5ab28055dbbb8f8191274410683f7144

5,ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/328e4434fcc94a3f2d4aa4ba796a0258

6,ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/be6cf700cc9eeeebdaaa2232bd36f35b

7,商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/82b530baac46f16256df8cba298483b5

